### PR TITLE
Add Mistral 7B model download to installer and handle alpha releases

### DIFF
--- a/.github/workflows/release_installer.yml
+++ b/.github/workflows/release_installer.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*.*.*"
+      - "v*.*.*.alpha"
 
 jobs:
   build-windows-installer:
@@ -53,6 +54,16 @@ jobs:
         with:
           additional-plugin-paths: "nsis-plugins"
 
+      - name: Check if alpha release
+        id: check_alpha
+        run: |
+          if ("${{ github.ref }}" -like "*.alpha") {
+            echo "is_alpha=true" >> $env:GITHUB_OUTPUT
+          } else {
+            echo "is_alpha=false" >> $env:GITHUB_OUTPUT
+          }
+        shell: pwsh
+
       - name: create release
         id: create_release
         uses: actions/create-release@v1
@@ -63,6 +74,8 @@ jobs:
           release_name: Release ${{ github.ref }}
           body: |
             This is a automated release completed by GitHub Actions.
+          draft: false
+          prerelease: ${{ steps.check_alpha.outputs.is_alpha == 'true' }}
 
       - name: Upload Installer
         id: upload-installer

--- a/install.nsi
+++ b/install.nsi
@@ -99,7 +99,7 @@
                 
                 ; Save new env settings for llm-container-launch
                 FileOpen $4 "$INSTDIR\local-llm-container\.env" w
-                FileWrite $4 "MODEL_NAME=/models/Mistral-7B-Instruct-v0.3-IQ3_M.gguf$\r$\n"
+                FileWrite $4 "MODEL_NAME=/models/Mistral-7B-Instruct-v0.3-Q8_0.gguf$\r$\n"
                 FileWrite $4 "CHAT_TEMPLATE=/models/mistral-instruct.jinja$\r$\n"
                 FileClose $4
             ${EndIf}

--- a/install.nsi
+++ b/install.nsi
@@ -749,8 +749,9 @@
 
         ; Setuo the defaults for s2t container
         ${If} $Is_Basic_Install == ${BST_CHECKED}
+            MessageBox MB_OK "Basic Install selected. Please note, the basic install will download the 8gb Mistral 7b AI Model. This may take a while, feel free to grab a coffee!"
 
-            # Add the required amount for mistral model
+            ; Add the required amount for mistral model
             SectionSetSize ${SEC_LLM} 8000000
             ; Create the .env directories for the Speech2Text container
             CreateDirectory "$INSTDIR\speech2text-container"

--- a/install.nsi
+++ b/install.nsi
@@ -89,6 +89,23 @@
             SetOutPath "$INSTDIR\local-llm-container"
             File ".\local-llm-container\*.*"
             StrCpy $LLM_Installed 1
+            ${If} $Is_Basic_Install == ${BST_CHECKED}
+  
+                ;download the quantized mistral model
+                inetc::get /TIMEOUT=30000 "https://huggingface.co/lmstudio-community/Mistral-7B-Instruct-v0.3-GGUF/resolve/main/Mistral-7B-Instruct-v0.3-IQ3_M.gguf?download=true" "$INSTDIR\local-llm-container\models\Mistral-7B-Instruct-v0.3-IQ3_M.gguf" /END
+                
+                ;download its template
+                inetc::get /TIMEOUT=30000 "https://github.com/chujiezheng/chat_templates/blob/main/chat_templates/mistral-instruct.jinja" "$INSTDIR\local-llm-container\models\mistral-instruct.jinja" /END
+                
+                ; Save new env settings for llm-container-launch
+                FileOpen $4 "$INSTDIR\local-llm-container\.env" w
+                FileWrite $4 "MODEL_NAME=/models/Mistral-7B-Instruct-v0.3-IQ3_M.gguf$\r$\n"
+                FileWrite $4 "CHAT_TEMPLATE=/models/mistral-instruct.jinja$\r$\n"
+                FileClose $4
+            ${EndIf}
+                
+                
+            
         SectionEnd
 
         Section "WSL2 for LLM" SEC_WSL_LLM
@@ -732,6 +749,9 @@
 
         ; Setuo the defaults for s2t container
         ${If} $Is_Basic_Install == ${BST_CHECKED}
+
+            # Add the required amount for mistral model
+            SectionSetSize ${SEC_LLM} 8000000
             ; Create the .env directories for the Speech2Text container
             CreateDirectory "$INSTDIR\speech2text-container"
 

--- a/install.nsi
+++ b/install.nsi
@@ -791,4 +791,9 @@
             ; Close the file
             FileClose $3
         ${EndIf}
+
+        ; If not basic set install size without mistral model
+        ${If} $Is_Adv_Install == ${BST_CHECKED}
+            SectionSetSize ${SEC_LLM} 43.0
+        ${EndIf}
     FunctionEnd

--- a/install.nsi
+++ b/install.nsi
@@ -92,7 +92,7 @@
             ${If} $Is_Basic_Install == ${BST_CHECKED}
   
                 ;download the quantized mistral model
-                inetc::get /TIMEOUT=30000 "https://huggingface.co/lmstudio-community/Mistral-7B-Instruct-v0.3-GGUF/resolve/main/Mistral-7B-Instruct-v0.3-IQ3_M.gguf?download=true" "$INSTDIR\local-llm-container\models\Mistral-7B-Instruct-v0.3-IQ3_M.gguf" /END
+                inetc::get /TIMEOUT=30000 "https://huggingface.co/lmstudio-community/Mistral-7B-Instruct-v0.3-GGUF/resolve/main/Mistral-7B-Instruct-v0.3-Q8_0.gguf?download=true" "$INSTDIR\local-llm-container\models\Mistral-7B-Instruct-v0.3-Q8_0.gguf" /END
                 
                 ;download its template
                 inetc::get /TIMEOUT=30000 "https://github.com/chujiezheng/chat_templates/blob/main/chat_templates/mistral-instruct.jinja" "$INSTDIR\local-llm-container\models\mistral-instruct.jinja" /END


### PR DESCRIPTION
## Summary by Sourcery

Enhance the installer to support the Mistral 7B AI model download and configuration during basic installation, and update the CI workflow to manage alpha releases.

New Features:
- Add support for downloading and configuring the Mistral 7B AI model during the basic installation process.

Enhancements:
- Update the installer script to include a message box notification for users selecting the basic install, informing them about the download of the Mistral 7B AI model.

CI:
- Modify the release workflow to handle alpha releases by checking the tag format and setting the prerelease status accordingly.