### PR TITLE
UI Changes and start docker before launching

### DIFF
--- a/install.nsi
+++ b/install.nsi
@@ -64,7 +64,8 @@
 
     ; Components page with condition
     !define MUI_PAGE_CUSTOMFUNCTION_PRE ShouldShowComponents
-    !insertmacro MUI_PAGE_COMPONENTS 
+    !define MUI_PAGE_CUSTOMFUNCTION_LEAVE ComponentsPageLeave
+    !insertmacro MUI_PAGE_COMPONENTS
 
     ; Directory page with condition
     !define MUI_PAGE_CUSTOMFUNCTION_PRE ShouldShowDirectory
@@ -243,6 +244,35 @@
         ${Else}
             MessageBox MB_OK "WSL2 download failed (Error: $R0). Please install WSL2 manually after the installation."
         ${EndIf}
+    FunctionEnd
+
+    Function ComponentsPageLeave
+        ; Initialize the count of selected components
+        StrCpy $0 0
+
+        ; Check if Local LLM is selected
+        SectionGetFlags ${SEC_LLM} $1
+        IntOp $1 $1 & ${SF_SELECTED}
+        StrCmp $1 ${SF_SELECTED} 0 +2
+            IntOp $0 $0 + 1
+
+        ; Check if Speech2Text is selected
+        SectionGetFlags ${SEC_S2T} $1
+        IntOp $1 $1 & ${SF_SELECTED}
+        StrCmp $1 ${SF_SELECTED} 0 +2
+            IntOp $0 $0 + 1
+
+        ; Check if FreeScribe is selected
+        SectionGetFlags ${SEC_FREESCRIBE} $1
+        IntOp $1 $1 & ${SF_SELECTED}
+        StrCmp $1 ${SF_SELECTED} 0 +2
+            IntOp $0 $0 + 1
+
+        ; If fewer than two components are selected, show a message and abort
+        IntCmp $0 1 +3 0 +3
+        MessageBox MB_OK "You must select at least one components to proceed."
+        Abort
+
     FunctionEnd
 
 ;--------------------------------

--- a/install.nsi
+++ b/install.nsi
@@ -76,10 +76,12 @@
     !insertmacro MUI_PAGE_INSTFILES
     Page custom FinishPageCreate FinishPageLeave
 
+; define uninstaller pages
     !insertmacro MUI_UNPAGE_CONFIRM
     !insertmacro MUI_UNPAGE_INSTFILES
     !insertmacro MUI_UNPAGE_FINISH
 
+; define language
     !insertmacro MUI_LANGUAGE "English"
 
 ;--------------------------------

--- a/install.nsi
+++ b/install.nsi
@@ -719,6 +719,10 @@
             Pop $0
         ${EndIf}
 
+        ; Get the handle of the "Close" button and change its text to "Finish"
+        GetDlgItem $0 $HWNDPARENT 1
+        SendMessage $0 ${WM_SETTEXT} 0 "STR:Finish"
+
         ; Display the dialog
         nsDialogs::Show
     FunctionEnd

--- a/install.nsi
+++ b/install.nsi
@@ -76,6 +76,10 @@
     !insertmacro MUI_PAGE_INSTFILES
     Page custom FinishPageCreate FinishPageLeave
 
+    !insertmacro MUI_UNPAGE_CONFIRM
+    !insertmacro MUI_UNPAGE_INSTFILES
+    !insertmacro MUI_UNPAGE_FINISH
+
     !insertmacro MUI_LANGUAGE "English"
 
 ;--------------------------------

--- a/install.nsi
+++ b/install.nsi
@@ -627,47 +627,55 @@
             Abort
         ${EndIf}
 
+        ; Initialize the vertical position for the first checkbox
+        StrCpy $1 0
+
         ; Create checkboxes for each installed component
         ; Only show checkboxes for components that were actually installed
         
         ; Check if LLM was installed and create its checkbox if true
         ${If} $LLM_Installed == 1
-            ${NSD_CreateCheckbox} 0u 0u 100% 12u "Launch Local LLM"
+            ${NSD_CreateCheckbox} 0u $1 100% 12u "Launch Local LLM"
             Pop $Checkbox_LLM
             ${NSD_SetState} $Checkbox_LLM ${BST_UNCHECKED}
+            IntOp $1 $1 + 20u ; Increment the vertical position for the next checkbox
         ${EndIf}
 
         ; Check if Speech2Text was installed and create its checkbox if true
         ${If} $Speech2Text_Installed == 1
-            ${NSD_CreateCheckbox} 0u 14u 100% 12u "Launch Speech2Text"
+            ${NSD_CreateCheckbox} 0u $1 100% 12u "Launch Speech2Text"
             Pop $Checkbox_Speech2Text
             ${NSD_SetState} $Checkbox_Speech2Text ${BST_UNCHECKED}
+            IntOp $1 $1 + 20u ; Increment the vertical position for the next checkbox
         ${EndIf}
 
         ; Check if FreeScribe was installed and create its checkbox if true
         ${If} $FreeScribe_Installed == 1
-            ${NSD_CreateCheckbox} 0u 28u 100% 12u "Launch FreeScribe"
+            ${NSD_CreateCheckbox} 0u $1 100% 12u "Launch FreeScribe"
             Pop $Checkbox_FreeScribe
             ${NSD_SetState} $Checkbox_FreeScribe ${BST_UNCHECKED}
+            IntOp $1 $1 + 20u ; Increment the vertical position for the next checkbox
         ${EndIf}
 
         
         ; Display a recommendation message if LLM or Speech2Text is installed
-    ${If} $LLM_Installed == 1
-    ${OrIf} $Speech2Text_Installed == 1
-        ; Create a bold label for the recommendation title
-        ${NSD_CreateLabel} 0u 42u 100% 12u "Recommended Actions:"
-        Pop $0
+        ${If} $LLM_Installed == 1
+        ${OrIf} $Speech2Text_Installed == 1
+            ; Create a bold label for the recommendation title
+            IntOp $1 $1 + 5u ; Increment the vertical position for the next checkbox
+            ${NSD_CreateLabel} 0u $1 100% 12u "Recommended Actions:"
+            Pop $0
+            IntOp $1 $1 + 20u ; Increment the vertical position for the next checkbox
 
-        ; Create a label for the first recommendation
-        ${NSD_CreateLabel} 0u 56u 100% 12u "1. Start Docker Desktop before launching Local LLM and Speech2Text."
-        Pop $0
+            ; Create a label for the first recommendation
+            ${NSD_CreateLabel} 0u $1 100% 12u "1. Start Docker Desktop before launching Local LLM and Speech2Text."
+            Pop $0
+            IntOp $1 $1 + 20u ; Increment the vertical position for the next checkbox
 
-        ; Create a label for the second recommendation
-        ${NSD_CreateLabel} 0u 70u 100% 12u "2. Launch Local LLM and Speech2Text to build the container image."
-        Pop $0
-
-    ${EndIf}
+            ; Create a label for the second recommendation
+            ${NSD_CreateLabel} 0u $1 100% 12u "2. Launch Local LLM and Speech2Text to build the container image."
+            Pop $0
+        ${EndIf}
 
         ; Display the dialog
         nsDialogs::Show

--- a/install.nsi
+++ b/install.nsi
@@ -64,6 +64,7 @@
 
     ; Components page with condition
     !define MUI_PAGE_CUSTOMFUNCTION_PRE ShouldShowComponents
+    ; Custom function to check if at least one component is selected
     !define MUI_PAGE_CUSTOMFUNCTION_LEAVE ComponentsPageLeave
     !insertmacro MUI_PAGE_COMPONENTS
 

--- a/install.nsi
+++ b/install.nsi
@@ -96,7 +96,7 @@
                 Call InstallWSL2
             ${Else}
                 ${If} $WSL_Installed_NotificationDone == 0
-                    MessageBox MB_OK "WSL2 is already installed on your system."
+                    DetailPrint "WSL2 is already installed on your system."
                     StrCpy $WSL_Installed_NotificationDone 1
                 ${EndIf}
             ${EndIf}
@@ -107,7 +107,7 @@
                 Call InstallDocker
             ${Else}
                 ${If} $Docker_Installed_NotificationDone == 0
-                    MessageBox MB_OK "Docker is already installed on your system."
+                    DetailPrint "Docker is already installed on your system."
                     StrCpy $Docker_Installed_NotificationDone 1
                 ${EndIf}
             ${EndIf}
@@ -148,7 +148,7 @@
                 Call InstallWSL2
             ${Else}
                 ${If} $WSL_Installed_NotificationDone == 0
-                    MessageBox MB_OK "WSL2 is already installed on your system."
+                    DetailPrint "WSL2 is already installed on your system."
                 ${EndIf}
             ${EndIf}
         SectionEnd
@@ -158,7 +158,7 @@
                 Call InstallDocker
             ${Else}
                 ${If} $Docker_Installed_NotificationDone == 0
-                    MessageBox MB_OK "Docker is already installed on your system."
+                    DetailPrint "Docker is already installed on your system."
                 ${EndIf}
             ${EndIf}
         SectionEnd

--- a/install.nsi
+++ b/install.nsi
@@ -274,7 +274,7 @@
         StrCmp $1 ${SF_SELECTED} 0 +2
             IntOp $0 $0 + 1
 
-        ; If fewer than two components are selected, show a message and abort
+        ; If user has selected 0 components, show a message and abort
         IntCmp $0 1 +3 0 +3
         MessageBox MB_OK "You must select at least one components to proceed."
         Abort

--- a/install.nsi
+++ b/install.nsi
@@ -75,7 +75,11 @@
     ; Custom pages
     Page custom ConditionalModelPageCreate ModelPageLeave
     Page custom ConditionalWhisperPageCreate WhisperSettingsPageLeave
+
+    ; Custom function called when leaving the InstallFiles page
+    !define MUI_PAGE_CUSTOMFUNCTION_LEAVE InsfilesPageLeave
     !insertmacro MUI_PAGE_INSTFILES
+
     Page custom FinishPageCreate FinishPageLeave
 
 ; define uninstaller pages
@@ -247,6 +251,7 @@
         ${EndIf}
     FunctionEnd
 
+    ; Function to execute when leaving the Component page
     Function ComponentsPageLeave
         ; Initialize the count of selected components
         StrCpy $0 0
@@ -274,6 +279,12 @@
         MessageBox MB_OK "You must select at least one components to proceed."
         Abort
 
+    FunctionEnd
+
+    ; Function to execute when leaving the InstallFiles page
+    ; Goes to the next page after the installation is complete
+    Function InsfilesPageLeave
+        SetAutoClose true
     FunctionEnd
 
 ;--------------------------------


### PR DESCRIPTION
**Issue** #21 #20 
### Changes
- Go to finish page directly after installation has completed.
- In component page, user has to select at least one component
- Show confirmation before uninstalling
- Recommended text in launch screen, telling user to start docker and launch local llm and speech2text container
- As a fallback in case user forgot to start docker, we start the docker before launching local llm or speech2text container
- Made final page elements position dynamic.

## Summary by Sourcery

Enhance the installation process by requiring at least one component selection, adding uninstall confirmation, and automatically starting Docker if needed. Improve UI by dynamically positioning final page elements and updating the finish page to directly follow installation completion.

New Features:
- Introduce a dynamic positioning system for final page elements to enhance UI flexibility.

Enhancements:
- Add a requirement for users to select at least one component on the components page before proceeding.
- Implement a confirmation dialog before uninstalling components to prevent accidental removals.
- Automatically start Docker if it is not running when launching local LLM or Speech2Text containers.