### PR TITLE
General bug fixes, running model post install, issue force running llm in installer, and default model in advanced tab. 

### DIFF
--- a/install.nsi
+++ b/install.nsi
@@ -620,9 +620,9 @@
         ShowWindow $0 ${SW_HIDE}
 
         ; Add items to dropdown
-        ${NSD_CB_AddString} $DropDown_Model "google/gemma-2-2b-it"
+        ${NSD_CB_AddString} $DropDown_Model "gemma2:2b-instruct-q8_0"
         ${NSD_CB_AddString} $DropDown_Model "Custom"
-        ${NSD_CB_SelectString} $DropDown_Model "google/gemma-2-2b-it"
+        ${NSD_CB_SelectString} $DropDown_Model "gemma2:2b-instruct-q8_0"
 
         ; Create input for Huggingface Token
         ${NSD_CreateLabel} 0u 44u 100% 12u "Huggingface Token:"

--- a/install.nsi
+++ b/install.nsi
@@ -807,7 +807,7 @@
             FileWrite $0 "    exit 1$\r$\n"
             FileWrite $0 "}$\r$\n"
             FileWrite $0 "Write-Host $\"Starting the Gemma model on Ollama...$\"$\r$\n"
-            FileWrite $0 "docker exec ollama ollama run gemma2:2b-instruct-q8_0:$\r$\n"
+            FileWrite $0 "docker exec ollama ollama run gemma2:2b-instruct-q8_0$\r$\n"
             FileWrite $0 "Write-Host $\"Gemma installed and launched on Ollama. You may now use the FreeScribe Client.$\"$\r$\n"
             FileWrite $0 "Write-Host $\"Press any key to continue...$\" -NoNewLine$\r$\n"
             FileWrite $0 "$$host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown') | Out-Null$\r$\n"

--- a/install.nsi
+++ b/install.nsi
@@ -781,8 +781,6 @@
 
         ; Check LLM checkbox state and launch if checked
         ${NSD_GetState} $Checkbox_LLM $0
-        StrCmp $0 ${BST_CHECKED} 0 +2
-
         ${If} $0 == ${BST_CHECKED}
             ; wait fir the container to be up before running the model
             ExecWait 'docker-compose -f "$INSTDIR\local-llm-container\docker-compose.yml" up -d --build'


### PR DESCRIPTION
## Summary by Sourcery

Update the NSIS installer to use the new 'gemma2:2b-instruct-q8_0' model version and fix issues related to model execution and checkbox state handling.

Bug Fixes:
- Fix a typo that prevented the model from running, which caused issues when serving the model to the client via endpoint.
- Resolve an issue where the local LLM would run even when the checkbox was not checked at the end of the installation.

Enhancements:
- Update the dropdown model selection in the NSIS installer to use 'gemma2:2b-instruct-q8_0' from the oLlama model library.