### PR TITLE
[Enhancement] Don't change API key on image update

### DIFF
--- a/install.nsi
+++ b/install.nsi
@@ -508,24 +508,29 @@
         ${NSD_CreateLabel} 0u 0u 100% 12u "Password (API Key):"
         ${NSD_CreateText} 0u 14u 100% 12u ""
         Pop $Input_APIKey
+
+        ; Create a button to generate the API key
+        ${NSD_CreateButton} 0u 28u 50% 12u "Generate API Key"
+        Pop $0
+        ${NSD_OnClick} $0 GenerateAPIKey
         
         ; Create description label for API key
-        ${NSD_CreateLabel} 0u 28u 100% 12u "This will be your password (API key) used to access the Whisper and LLM services"
+        ${NSD_CreateLabel} 0u 42u 100% 12u "This will be your password (API key) used to access the Whisper and LLM services"
         Pop $0
         SetCtlColors $0 808080 transparent
 
         ; Create a label for the model selection
-        ${NSD_CreateLabel} 0u 44u 100% 12u "Select Whisper Model:"
-        ${NSD_CreateComboBox} 0u 58u 100% 12u ""
+        ${NSD_CreateLabel} 0u 58u 100% 12u "Select Whisper Model:"
+        ${NSD_CreateComboBox} 0u 72u 100% 12u ""
         Pop $DropDown_WhisperModel
 
         ; Create description label for model selection
-        ${NSD_CreateLabel} 0u 72u 100% 12u "Choose model size (larger models are more accurate but slower) - 'medium' recommended"
+        ${NSD_CreateLabel} 0u 86u 100% 12u "Choose model size (larger models are more accurate but slower) - 'medium' recommended"
         Pop $0
         SetCtlColors $0 808080 transparent
 
         ; Add more detailed model descriptions
-        ${NSD_CreateLabel} 0u 86u 100% 48u "tiny: Fastest, least accurate (1GB)$\nbase: Fast, basic accuracy (1GB)$\nsmall: Balanced speed/accuracy (2GB)$\nmedium: Good accuracy (5GB)$\nlarge: Best accuracy, slowest (10GB)"
+        ${NSD_CreateLabel} 0u 100u 100% 48u "tiny: Fastest, least accurate (1GB)$\nbase: Fast, basic accuracy (1GB)$\nsmall: Balanced speed/accuracy (2GB)$\nmedium: Good accuracy (5GB)$\nlarge: Best accuracy, slowest (10GB)"
         Pop $0
         SetCtlColors $0 808080 transparent
 
@@ -1228,6 +1233,9 @@
             MessageBox MB_OK "Error: Could not generate API key."
             Abort
         ${EndIf}
+
+        ; Set the generated API key in the text box
+        ${NSD_SetText} $Input_APIKey $APIKey
     FunctionEnd
 
     ;------------------------------------------------------------------------------

--- a/install.nsi
+++ b/install.nsi
@@ -545,11 +545,11 @@
 
     Function HasEnvFiles
         ; Check if the .env files exist
-        IfFileExists "$INSTDIR\speech2text-container\.env" 0 3
+        IfFileExists "$INSTDIR\speech2text-container\.env" 0 +3
             StrCpy $S2THasEnv 1
 
         
-        IfFileExists "$INSTDIR\local-llm-container\.env" 0 3
+        IfFileExists "$INSTDIR\local-llm-container\.env" 0 +3
             StrCpy $LLMHasEnv 1
 
 
@@ -557,7 +557,7 @@
     
 
     !macro WriteEnvFiles APIKey WhisperModel
-        ${If} $S2THasEnv == 1
+        ${If} $S2THasEnv != 1
         ; Create the .env directories for the Whisper settings
             CreateDirectory "$INSTDIR\speech2text-container"
 
@@ -580,7 +580,7 @@
             FileClose $3
         ${EndIf}
 
-        ${If} $LLMHasEnv == 1        
+        ${If} $LLMHasEnv != 1        
             ; Create the .env directories for the Whisper settings
             CreateDirectory "$INSTDIR\local-llm-container"
 

--- a/install.nsi
+++ b/install.nsi
@@ -1089,7 +1089,9 @@
     ; Function to check if Docker is running and start it if not
     Function CheckAndStartDocker
         ; Check if Docker is running
-        ExecWait 'docker info' $0
+        nsExec::ExecToStack 'docker info'
+        Pop $0
+        Pop $1
         StrCmp $0 0 done
 
         ; If Docker is not running, start Docker Desktop
@@ -1098,7 +1100,9 @@
         Sleep 5000 ; Wait for Docker to start
 
         ; Check again if Docker is running
-        ExecWait 'docker info' $0
+        nsExec::ExecToStack 'docker info'
+        Pop $0
+        Pop $1
         StrCmp $0 0 done
 
         ; If Docker still isn't running, show an error message

--- a/install.nsi
+++ b/install.nsi
@@ -556,6 +556,17 @@
         nsDialogs::Show
     FunctionEnd
 
+    !macro HasEnvFiles Container
+        ; Check if the .env files exist
+        IfFileExists "$INSTDIR\$Container\.env" EnvFound EnvNotFound
+
+        EnvFound:
+            Return 1
+        EnvNotFound:
+            Return 0
+    !macroend
+    
+
     !macro WriteEnvFiles APIKey WhisperModel
         ; Create the .env directories for the Whisper settings
         CreateDirectory "$INSTDIR\speech2text-container"
@@ -603,8 +614,6 @@
         ; Call the macro to write the .env files
         !insertmacro WriteEnvFiles $APIKey $WhisperModel
     FunctionEnd
-
-    
 
 ;--------------------------------
 ;Descriptions

--- a/install.nsi
+++ b/install.nsi
@@ -1124,7 +1124,8 @@
         ; Check Speech2Text checkbox state and launch if checked
         ${NSD_GetState} $Checkbox_Speech2Text $0
         StrCmp $0 ${BST_CHECKED} 0 +2
-            Exec 'docker-compose -f "$INSTDIR\speech2text-container\docker-compose.yml" build --no-cache && docker-compose -f "$INSTDIR\speech2text-container\docker-compose.yml" up -d'
+            ExecWait 'docker-compose -f "$INSTDIR\speech2text-container\docker-compose.yml" build --no-cache'
+            ExecWait 'docker-compose -f "$INSTDIR\speech2text-container\docker-compose.yml" up -d'
 
         ; Check LLM checkbox state and launch if checked
         ${NSD_GetState} $Checkbox_LLM $0

--- a/install.nsi
+++ b/install.nsi
@@ -1124,15 +1124,13 @@
         ; Check Speech2Text checkbox state and launch if checked
         ${NSD_GetState} $Checkbox_Speech2Text $0
         StrCmp $0 ${BST_CHECKED} 0 +2
-            ExecWait 'docker-compose -f "$INSTDIR\speech2text-container\docker-compose.yml" build --no-cache'
-            ExecWait 'docker-compose -f "$INSTDIR\speech2text-container\docker-compose.yml" up -d'
+            Exec 'docker-compose -f "$INSTDIR\speech2text-container\docker-compose.yml" up -d --build'
 
         ; Check LLM checkbox state and launch if checked
         ${NSD_GetState} $Checkbox_LLM $0
         ${If} $0 == ${BST_CHECKED}
             ; wait fir the container to be up before running the model
-            ExecWait 'docker-compose -f "$INSTDIR\local-llm-container\docker-compose.yml" build --no-cache'
-            ExecWait 'docker-compose -f "$INSTDIR\local-llm-container\docker-compose.yml" up -d'
+            ExecWait 'docker-compose -f "$INSTDIR\local-llm-container\docker-compose.yml" up -d --build'
             ${For} $R1 0 30
                 ExecWait 'docker container inspect -f "{{.State.Running}}" ollama' $0
                 ${If} $0 == 0

--- a/install.nsi
+++ b/install.nsi
@@ -1120,13 +1120,15 @@
         ; Check Speech2Text checkbox state and launch if checked
         ${NSD_GetState} $Checkbox_Speech2Text $0
         StrCmp $0 ${BST_CHECKED} 0 +2
-            Exec 'docker-compose -f "$INSTDIR\speech2text-container\docker-compose.yml" up -d --build'
+            ExecWait 'docker-compose -f "$INSTDIR\speech2text-container\docker-compose.yml" build --no-cache'
+            ExecWait 'docker-compose -f "$INSTDIR\speech2text-container\docker-compose.yml" up -d'
 
         ; Check LLM checkbox state and launch if checked
         ${NSD_GetState} $Checkbox_LLM $0
         ${If} $0 == ${BST_CHECKED}
             ; wait fir the container to be up before running the model
-            ExecWait 'docker-compose -f "$INSTDIR\local-llm-container\docker-compose.yml" up -d --build'
+            ExecWait 'docker-compose -f "$INSTDIR\local-llm-container\docker-compose.yml" build --no-cache'
+            ExecWait 'docker-compose -f "$INSTDIR\local-llm-container\docker-compose.yml" up -d'
             ${For} $R1 0 30
                 ExecWait 'docker container inspect -f "{{.State.Running}}" ollama' $0
                 ${If} $0 == 0

--- a/install.nsi
+++ b/install.nsi
@@ -1261,6 +1261,9 @@
 
         ; If not basic set install size without mistral model
         ${If} $Is_Adv_Install == ${BST_CHECKED}
+            ; to make sure that new env files are created in advanced mode
+            StrCpy $S2THasEnv 0
+            StrCpy $LLMHasEnv 0
             SectionSetSize ${SEC_LLM} 43.0
         ${EndIf}
     FunctionEnd

--- a/install.nsi
+++ b/install.nsi
@@ -185,26 +185,9 @@
         Section "Speech2Text-Container Module" SEC_S2T
             CreateDirectory "$INSTDIR\speech2text-container"
             
-            ${If} $Is_Adv_Install == ${BST_CHECKED}
-                ; Save new env stuff to memory
-                FileOpen $4 "$INSTDIR\speech2text-container\.env" r
-                FileSeek $4 0 ; we want to start reading at the 1000th byte
-                FileRead $4 $1 ; we read until the end of line (including carriage return and new line) and save it to $1
-                FileRead $4 $2 ; read 10 characters from the next line
-                FileClose $4 ; and close the file
-            ${EndIf}
-            
             ;; Copy in new files
             SetOutPath "$INSTDIR\speech2text-container"
             File ".\speech2text-container\*.*"
-
-            ${If} $Is_Adv_Install == ${BST_CHECKED}
-                ; Set the new env stuff into env file since it just got replaced
-                FileOpen $4 "$INSTDIR\speech2text-container\.env" w
-                FileWrite $4 $1
-                FileWrite $4 $2
-                FileClose $4
-            ${EndIf}
 
             StrCpy $Speech2Text_Installed 1
         SectionEnd

--- a/install.nsi
+++ b/install.nsi
@@ -817,10 +817,31 @@
         ; Initialize the vertical position for the first checkbox
         StrCpy $1 0
 
-        ; Create a label for the API key
-        ${NSD_CreateLabel} 0u $1 100% 12u "API Key (LLM and S2T):"
-        Pop $0
-        IntOp $1 $1 + 20 ; Increment the vertical position
+        ${If} $S2THasEnv != 1
+            ${If} $LLMHasEnv != 1
+                ; Create a label for the API key
+                ${NSD_CreateLabel} 0u $1 100% 12u "API Key (LLM and S2T):"
+                Pop $0
+                IntOp $1 $1 + 20 ; Increment the vertical position
+            ${Else}
+                ; Create a label for the API key
+                ${NSD_CreateLabel} 0u $1 100% 12u "API Key (S2T)"
+                Pop $0
+                IntOp $1 $1 + 20 ; Increment the vertical position
+            ${EndIf}
+        ${ElseIf} $LLMHasEnv != 1
+            ; Create a label for the API key
+            ${NSD_CreateLabel} 0u $1 100% 12u "API Key (LLM)"
+            Pop $0
+            IntOp $1 $1 + 20 ; Increment the vertical position
+        ${Else}
+            ; Create a label for the API key
+            ${NSD_CreateLabel} 0u $1 100% 12u "API Key not changed for both LLM and S2T"
+            Pop $0
+            IntOp $1 $1 + 20 ; Increment the vertical position
+
+            StrCpy $APIKey "Not Changed"
+        ${EndIf}
 
         ; Create an Edit control to display the API key
         ${NSD_CreateText} 0u $1 100% 12u "$APIKey"

--- a/install.nsi
+++ b/install.nsi
@@ -1124,8 +1124,7 @@
         ; Check Speech2Text checkbox state and launch if checked
         ${NSD_GetState} $Checkbox_Speech2Text $0
         StrCmp $0 ${BST_CHECKED} 0 +2
-            ExecWait 'docker-compose -f "$INSTDIR\speech2text-container\docker-compose.yml" build --no-cache'
-            ExecWait 'docker-compose -f "$INSTDIR\speech2text-container\docker-compose.yml" up -d'
+            Exec 'docker-compose -f "$INSTDIR\speech2text-container\docker-compose.yml" build --no-cache && docker-compose -f "$INSTDIR\speech2text-container\docker-compose.yml" up -d'
 
         ; Check LLM checkbox state and launch if checked
         ${NSD_GetState} $Checkbox_LLM $0


### PR DESCRIPTION
### Issue
- #47 

### Changes
- Created new API page in advanced mode.
- Checking if env file already exists to know if there is an existing API key. Basic installation uses the existing API key and advanced installation changes API key

## Summary by Sourcery

Enhancements:
- Introduce a new API page in advanced mode to manage API keys without changing them during image updates.