### PR TITLE
Add Copy to Clipboard buttons for Keys+Endpoints and Fixed return char issue

### DIFF
--- a/install.nsi
+++ b/install.nsi
@@ -1128,6 +1128,12 @@ FunctionEnd
         IntOp $1 $1 + 1
         IntOp $1 $1 * 2 ; Multiply by 2 for wide chars
         System::Call 'kernel32::GlobalAlloc(i 2, i r1) i.r1'
+        StrCmp $r1 0 AllocationFailed
+        goto ContinueAlloc
+        AllocationFailed:
+        MessageBox MB_ICONEXCLAMATION "GlobalAlloc failed"
+        Abort
+        ContinueAlloc:
         System::Call 'kernel32::GlobalLock(i r1) i.r2'
         System::Call 'kernel32::lstrcpyW(i r2, w r0)' ; Changed A to W and t to w
         System::Call 'kernel32::GlobalUnlock(i r1)'

--- a/install.nsi
+++ b/install.nsi
@@ -1431,6 +1431,11 @@ FunctionEnd
         Pop $0
         Pop $APIKey
 
+        ; Trim the trailing newlines from the API key
+        Push $APIKey
+        Call TrimTrailingNewlines
+        Pop $APIKey
+
         ${If} $0 != 0
             MessageBox MB_OK "Error: Could not generate API key."
             Abort

--- a/install.nsi
+++ b/install.nsi
@@ -1051,10 +1051,15 @@ FunctionEnd
         ${EndIf}
 
         ; Create an Edit control to display the API key
-        ${NSD_CreateText} 0u $1 100% 12u "$APIKey"
+        ${NSD_CreateText} 0u $1 75% 12u "$APIKey"
         Pop $0
         ; Make the text box read-only
         SendMessage $0 ${EM_SETREADONLY} 1 0
+
+        ${NSD_CreateButton} 80% $1 20% 12u "Copy API Key"
+        Pop $0
+        ${NSD_OnClick} $0 CopyAPIKey
+
         IntOp $1 $1 + 25 ; Increment the vertical position
 
         ${If} $LLM_Installed == 1
@@ -1064,10 +1069,14 @@ FunctionEnd
             IntOp $1 $1 + 20 ; Increment the vertical position
 
             ; Create an Edit control to display the IP address
-            ${NSD_CreateText} 0u $1 100% 12u "https://$PrimaryIP:3334/v1"
+            ${NSD_CreateText} 0u $1 75% 12u "https://$PrimaryIP:3334/v1"
             Pop $0
             ; Make the text box read-only
             SendMessage $0 ${EM_SETREADONLY} 1 0
+
+            ${NSD_CreateButton} 80% $1 20% 12u "Copy Endpoint"
+            Pop $0
+            ${NSD_OnClick} $0 CopyLLMEndpoint
             IntOp $1 $1 + 25 ; Increment the vertical position
         ${EndIf}
         
@@ -1078,16 +1087,117 @@ FunctionEnd
             IntOp $1 $1 + 20 ; Increment the vertical position
 
             ; Create an Edit control to display the IP address
-            ${NSD_CreateText} 0u $1 100% 12u "https://$PrimaryIP:2224/whisperaudio"
+            ${NSD_CreateText} 0u $1 75% 12u "https://$PrimaryIP:2224/whisperaudio"
             Pop $0
             ; Make the text box read-only
             SendMessage $0 ${EM_SETREADONLY} 1 0
-            IntOp $1 $1 + 20 ; Increment the vertical position
+
+            ${NSD_CreateButton} 80% $1 20% 12u "Copy Endpoint"
+            Pop $0
+            ${NSD_OnClick} $0 CopyS2TEndpoint
+            IntOp $1 $1 + 25 ; Increment the vertical position
         ${EndIf}
 
         nsDialogs::Show
 
     FunctionEnd
+
+    Function CopyToClipboard
+        ;------------------------------------------------------------------------------
+        ; Function: CopyToClipboard
+        ; Purpose: trims the return char off of a string
+        ; 
+        ; Parameters:
+        ;   Stack 0: The string to copy to clipboard
+        ;
+        ; Returns:
+        ;   none
+        ;
+        ; Example:
+        ;   Push "Test string"    ; First version
+        ;   Call CopyToClipboard
+        ;   ; windows keyboard now has text in it
+        ;------------------------------------------------------------------------------
+        ; code from https://nsis.sourceforge.io/Copy_to,_or_get_from_Windows_Clipboard
+        Exch $0 ;input string
+        Push $1
+        Push $2
+        System::Call 'user32::OpenClipboard(i 0)'
+        System::Call 'user32::EmptyClipboard()'
+        StrLen $1 $0
+        IntOp $1 $1 + 1
+        IntOp $1 $1 * 2 ; Multiply by 2 for wide chars
+        System::Call 'kernel32::GlobalAlloc(i 2, i r1) i.r1'
+        System::Call 'kernel32::GlobalLock(i r1) i.r2'
+        System::Call 'kernel32::lstrcpyW(i r2, w r0)' ; Changed A to W and t to w
+        System::Call 'kernel32::GlobalUnlock(i r1)'
+        System::Call 'user32::SetClipboardData(i 13, i r1)' ; CF_UNICODETEXT is 13
+        System::Call 'user32::CloseClipboard()'
+        Pop $2
+        Pop $1
+        Pop $0
+    FunctionEnd
+
+    Function CopyS2TEndpoint
+        ;------------------------------------------------------------------------------
+        ; Function: CopyS2TEndpoint
+        ; Purpose: Copies the S2T endpoint to the clipboard
+        ; 
+        ; Parameters:
+        ;   None
+        ;
+        ; Returns:
+        ;   none
+        ;
+        ; Example:
+        ;   Call CopyS2TEndpoint
+        ;   ; windows keyboard now has text in it
+        ;------------------------------------------------------------------------------
+        ; Copy the S2T endpoint to the clipboard
+        Push "https://$PrimaryIP:2224/whisperaudio"
+        Call CopyToClipboard
+    FunctionEnd
+
+    Function CopyLLMEndpoint
+        ;------------------------------------------------------------------------------
+        ; Function: CopyLLMEndpoint
+        ; Purpose: Copies the LLM endpoint to the clipboard
+        ; 
+        ; Parameters:
+        ;   None
+        ;
+        ; Returns:
+        ;   none
+        ;
+        ; Example:
+        ;   Call CopyLLMEndpoint
+        ;   ; windows keyboard now has text in it
+        ;------------------------------------------------------------------------------
+        ; Copy the LLM endpoint to the clipboard
+        Push "https://$PrimaryIP:3334/v1"
+        Call CopyToClipboard
+    FunctionEnd
+
+    Function CopyAPIKey
+        ;------------------------------------------------------------------------------
+        ; Function: CopyAPIKey
+        ; Purpose: Copies the API endpoint to the clipboard
+        ; 
+        ; Parameters:
+        ;   None
+        ;
+        ; Returns:
+        ;   none
+        ;
+        ; Example:
+        ;   Call CopyS2TEndpoint
+        ;   ; windows keyboard now has text in it
+        ;------------------------------------------------------------------------------
+        ; Copy the API key to the clipboard
+        Push $APIKey
+        Call CopyToClipboard
+    FunctionEnd
+
 
 ;--------------------------------
 ;Generate Api Key Page Customization using nsDialogs


### PR DESCRIPTION
trim trailing return chars that wouldnt show when pasted into the clientand cause connection errors.

## Summary by Sourcery

Adds functionality to copy the API key, LLM endpoint, and S2T endpoint to the clipboard during installation. Also includes a function to trim trailing newlines from a string.

New Features:
- Adds buttons to copy the API key, LLM endpoint, and S2T endpoint to the clipboard during installation.
- Introduces a function to trim trailing newlines from a string, used to clean up the API key and IP address.