### PR TITLE
Check if api key and custom model is provided

### DIFF
--- a/install.nsi
+++ b/install.nsi
@@ -1080,6 +1080,12 @@ FunctionEnd
     Function ApiPageLeave
         ; Get the API key entered by the user
         ${NSD_GetText} $Input_APIKey $APIKey
+
+        ; Prevent leaving the page if the API key is empty
+        StrCmp $APIKey "" 0 +3
+        MessageBox MB_OK "Please enter or generate an API Key before proceeding."
+        Abort
+
     FunctionEnd
 
 ;--------------------------------

--- a/install.nsi
+++ b/install.nsi
@@ -1166,8 +1166,16 @@ FunctionEnd
 
     Function ModelPageLeave
         ${NSD_GetText} $DropDown_Model $1  ; $0 will hold the user input
-        StrCmp $1 "Custom" 0 +2
+        StrCmp $1 "Custom" +2
+            Goto NotCustomModel
         ${NSD_GetText} $Input_CustomModel $1
+
+        ; Prevent leaving the page if the Custom model is empty
+        StrCmp $1 "" 0 +3
+        MessageBox MB_OK "Please enter or select a model before proceeding."
+        Abort
+        
+        NotCustomModel:
         
         ; ; Get the Huggingface token
         ; ${NSD_GetText} $Input_HFToken $2


### PR DESCRIPTION
## Summary by Sourcery

Add validation to ensure API key and custom model are not left empty during installation

Bug Fixes:
- Prevent user from proceeding with empty API key in the installer
- Prevent user from proceeding with empty custom model when 'Custom' model is selected